### PR TITLE
Fix impossible blob name check

### DIFF
--- a/packages/cma-client-browser/src/utils/uploadFileOrBlobAndReturnPath.ts
+++ b/packages/cma-client-browser/src/utils/uploadFileOrBlobAndReturnPath.ts
@@ -34,11 +34,17 @@ export function uploadFileOrBlobAndReturnPath(
   fileOrBlob: File | Blob,
   options: Options = {},
 ): CancelablePromise<string> {
-  if (!(options.filename && 'name' in fileOrBlob)) {
+  let filename: string;
+
+  if (options.filename) {
+    // If a filename is explicitly provided, use it
+    filename = options.filename;
+  } else if (fileOrBlob instanceof File && fileOrBlob.name) {
+    // Files extend Blobs and may have a `name` property. Blobs never have names.
+    filename = fileOrBlob.name;
+  } else {
     throw new Error('Missing filename, please provide it as an option!');
   }
-
-  const filename = options.filename || fileOrBlob.name;
 
   let isCanceledBeforeUpload = false;
   let uploadPromise: CancelablePromise<void> | undefined = undefined;


### PR DESCRIPTION
This partially fixes an issue with being able to upload JS `Blobs`, as reported on the forum: https://community.datocms.com/t/createupload-fails-with-missing-filename/4886/

We had an [`if` statement](https://github.com/datocms/js-rest-api-clients/blob/main/packages/cma-client-browser/src/utils/uploadFileOrBlobAndReturnPath.ts#L37):

```js
  if (!(options.filename && 'name' in fileOrBlob)) {
    throw new Error('Missing filename, please provide it as an option!');
  }
```
This would always be false if `fileOrBlob` was a `Blob`, because `Blobs` don't have a `name` property (only `Files` do).