### PR TITLE
Update idUtils.ts to allow integer IDs

### DIFF
--- a/packages/cma-client-browser/package.json
+++ b/packages/cma-client-browser/package.json
@@ -2,10 +2,7 @@
   "name": "@datocms/cma-client-browser",
   "version": "3.3.3",
   "description": "Browser client for DatoCMS REST Content Management API",
-  "keywords": [
-    "datocms",
-    "client"
-  ],
+  "keywords": ["datocms", "client"],
   "author": "Stefano Verna <s.verna@datocms.com>",
   "homepage": "https://github.com/datocms/js-rest-api-clients/tree/main/packages/cma-client-browser#readme",
   "license": "MIT",
@@ -16,10 +13,7 @@
     "lib": "dist",
     "test": "__tests__"
   },
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cma-client-node/package.json
+++ b/packages/cma-client-node/package.json
@@ -2,10 +2,7 @@
   "name": "@datocms/cma-client-node",
   "version": "3.3.3",
   "description": "NodeJS client for DatoCMS REST Content Management API",
-  "keywords": [
-    "datocms",
-    "client"
-  ],
+  "keywords": ["datocms", "client"],
   "author": "Stefano Verna <s.verna@datocms.com>",
   "homepage": "https://github.com/datocms/js-rest-api-clients/tree/main/packages/cma-client-node#readme",
   "license": "MIT",
@@ -16,10 +13,7 @@
     "lib": "dist",
     "test": "__tests__"
   },
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cma-client/package.json
+++ b/packages/cma-client/package.json
@@ -2,10 +2,7 @@
   "name": "@datocms/cma-client",
   "version": "3.3.3",
   "description": "JS client for DatoCMS REST Content Management API",
-  "keywords": [
-    "datocms",
-    "client"
-  ],
+  "keywords": ["datocms", "client"],
   "author": "Stefano Verna <s.verna@datocms.com>",
   "homepage": "https://github.com/datocms/js-rest-api-clients/tree/main/packages/cma-client#readme",
   "license": "MIT",
@@ -17,11 +14,7 @@
     "lib": "dist",
     "test": "__tests__"
   },
-  "files": [
-    "dist",
-    "src",
-    "resources.json"
-  ],
+  "files": ["dist", "src", "resources.json"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cma-client/src/idUtils.ts
+++ b/packages/cma-client/src/idUtils.ts
@@ -34,6 +34,13 @@ function fromUrlSafeBase64toUint8Array(urlSafeBase64: string): Uint8Array {
 }
 
 export function isValidId(id: string) {
+  // For backward compatibility, first check to see if this is an older-style integer ID formerly used by Dato
+  if (/^\d+$/.test(id)) {
+    const intId = BigInt(id);
+    const maxDatoIntegerId = 281474976710655; // Max 6-byte/48-bit unsigned int
+    return intId <= maxDatoIntegerId;
+  }
+
   const bytes = fromUrlSafeBase64toUint8Array(id);
 
   // UUIDs are 16 bytes

--- a/packages/dashboard-client/package.json
+++ b/packages/dashboard-client/package.json
@@ -2,10 +2,7 @@
   "name": "@datocms/dashboard-client",
   "version": "3.3.3",
   "description": "JS client for DatoCMS REST Content Management API",
-  "keywords": [
-    "datocms",
-    "client"
-  ],
+  "keywords": ["datocms", "client"],
   "author": "Stefano Verna <s.verna@datocms.com>",
   "homepage": "https://github.com/datocms/js-rest-api-clients/tree/main/packages/cma-client#readme",
   "license": "MIT",
@@ -17,11 +14,7 @@
     "lib": "dist",
     "test": "__tests__"
   },
-  "files": [
-    "dist",
-    "src",
-    "resources.json"
-  ],
+  "files": ["dist", "src", "resources.json"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rest-api-events/package.json
+++ b/packages/rest-api-events/package.json
@@ -2,10 +2,7 @@
   "name": "@datocms/rest-api-events",
   "version": "3.3.3",
   "description": "Utilities to receive real-time events from DatoCMS REST APIs",
-  "keywords": [
-    "datocms",
-    "client"
-  ],
+  "keywords": ["datocms", "client"],
   "author": "Stefano Verna <s.verna@datocms.com>",
   "homepage": "https://github.com/datocms/js-rest-api-clients/tree/main/packages/rest-api-events#readme",
   "license": "MIT",
@@ -17,10 +14,7 @@
     "lib": "dist",
     "test": "__tests__"
   },
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rest-client-utils/package.json
+++ b/packages/rest-client-utils/package.json
@@ -2,10 +2,7 @@
   "name": "@datocms/rest-client-utils",
   "version": "3.3.3",
   "description": "Utilities for DatoCMS REST API clients",
-  "keywords": [
-    "datocms",
-    "client"
-  ],
+  "keywords": ["datocms", "client"],
   "author": "Stefano Verna <s.verna@datocms.com>",
   "homepage": "https://github.com/datocms/js-rest-api-clients/tree/main/packages/rest-client-utils#readme",
   "license": "MIT",
@@ -17,10 +14,7 @@
     "lib": "dist",
     "test": "__tests__"
   },
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
@stefanoverna did we mean to leave out old-style integer IDs from the `isValidId()`  check? The GraphQL layer still allows those through, and some of our older demo projects still use integers too.