### PR TITLE
New version: 3.3.4 w/ integer ID fix

### DIFF
--- a/packages/cma-client/package.json
+++ b/packages/cma-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datocms/cma-client",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "JS client for DatoCMS REST Content Management API",
   "keywords": ["datocms", "client"],
   "author": "Stefano Verna <s.verna@datocms.com>",


### PR DESCRIPTION
@stefanoverna or @matjack1 Could we please put out a new version release to publish the fix at https://github.com/datocms/js-rest-api-clients/pull/28)? A customer is waiting for it (https://community.datocms.com/t/best-way-to-handle-not-found-on-itemid-lookups/5148/7?u=roger)

This change should be considered a bugfix, IMO. The `isValidId()` function was previously rejecting integer IDs even though they were valid. That's been fixed. UUID-style IDs continue to work as before.

I don't believe I have credentials to publish to NPM directly. Would you mind taking a sec to do that after merging this PR, please?

Thanks!