### PR TITLE
Fix serializeRequestBody() body.type vs options.type parsing

### DIFF
--- a/packages/rest-client-utils/src/serialize.ts
+++ b/packages/rest-client-utils/src/serialize.ts
@@ -49,7 +49,7 @@ export function serializeRequestBody<T extends { data: unknown } | null>(
     } as unknown as T;
   }
 
-  const { id, type, meta, ...otherProperties } = body as any;
+  const { id, meta, ...otherProperties } = body as any;
 
   const attributes: Record<string, unknown> = {};
   const relationships: Record<string, unknown> = {};

--- a/packages/rest-client-utils/src/serialize.ts
+++ b/packages/rest-client-utils/src/serialize.ts
@@ -116,7 +116,7 @@ export function serializeRequestBody<T extends { data: unknown } | null>(
   return {
     data: {
       ...(id || options.id ? { id: id || options.id } : {}),
-      type: type || options.type,
+      type: options.type, // If a body.type is passed in, it should go in data.attributes. Only options.type should be here at the root.
       ...(Object.keys(attributes).length > 0 ? { attributes } : {}),
       ...(Object.keys(relationships).length > 0 ? { relationships } : {}),
       ...(meta ? { meta } : {}),


### PR DESCRIPTION
`serializeRequestBody()` was mis-applying the `body.type` parameter into its `data.type` output, instead of `data.attributes.type` where it would belong. This was breaking `uploadTracks.create()` because it passes in both a body.type and an options.type, e.g.:

```js

const {serializeRequestBody} = require("@datocms/rest-client-utils");

const body = {
    type: 'subtitles',
    'url_or_upload_request_id': 'test',
}

console.log(serializeRequestBody(body, {
    type: 'upload_track',
    attributes: [
        'url_or_upload_request_id',
        'type',
        'name',
        'language_code',
        'closed_captions',
    ],
    relationships: [],
}));
```

That was incorrectly returning:
```js
{
  data: {
    type: 'subtitles', // This is wrong, should be 'upload_track'
    attributes: { url_or_upload_request_id: 'test' } // This is missing 'subtitles'
  }
}
```

Fixed version instead returns:
```js
{
  data: {
    type: 'upload_track',
    attributes: { type: 'subtitles', url_or_upload_request_id: 'test' }
  }
}

```

