### PR TITLE
Make appearance.parameters truly optional

### DIFF
--- a/packages/cma-client/src/fieldTypes/appearance/color_picker.ts
+++ b/packages/cma-client/src/fieldTypes/appearance/color_picker.ts
@@ -2,8 +2,8 @@
  * Built-in editor for Color fields.
  */
 export type ColorPickerEditorConfiguration = {
-  /** Should the color picker allow to specify the alpha value? */
-  enable_alpha: boolean;
-  /** List of preset colors to offer to the user (hex color strings) */
-  preset_colors: Array<string>;
+  /** Should the color picker allow to specify the alpha value? (default: false) */
+  enable_alpha?: boolean;
+  /** List of preset colors to offer to the user (hex color strings) (default: []) */
+  preset_colors?: Array<string>;
 };

--- a/packages/cma-client/src/fieldTypes/appearance/framed_single_block.ts
+++ b/packages/cma-client/src/fieldTypes/appearance/framed_single_block.ts
@@ -2,6 +2,6 @@
  * Built-in editor for Single block fields.
  */
 export type FramedSingleBlockEditorConfiguration = {
-  /** Whether you want block record collapsed by default or not */
+  /** Whether you want block record collapsed by default or not (default: false) */
   start_collapsed?: boolean;
 };

--- a/packages/cma-client/src/fieldTypes/appearance/markdown.ts
+++ b/packages/cma-client/src/fieldTypes/appearance/markdown.ts
@@ -2,8 +2,8 @@
  * Markdown editor for Multiple-paragraph text fields.
  */
 export type MarkdownEditorConfiguration = {
-  /** Specify which buttons the toolbar should have */
-  toolbar: Array<
+  /** Specify which buttons the toolbar should have (default: all allowed values) */
+  toolbar?: Array<
     | 'heading'
     | 'bold'
     | 'italic'

--- a/packages/cma-client/src/fieldTypes/appearance/rich_text.ts
+++ b/packages/cma-client/src/fieldTypes/appearance/rich_text.ts
@@ -2,6 +2,6 @@
  * Built-in editor for Modular content fields.
  */
 export type RichTextEditorConfiguration = {
-  /** Whether you want block records collapsed by default or not */
+  /** Whether you want block records collapsed by default or not (default: false) */
   start_collapsed?: boolean;
 };

--- a/packages/cma-client/src/fieldTypes/appearance/seo.ts
+++ b/packages/cma-client/src/fieldTypes/appearance/seo.ts
@@ -2,12 +2,12 @@
  * Built-in editor for SEO fields.
  */
 export type SeoEditorConfiguration = {
-  /** Specify which fields of the SEO input should be visible to editors */
-  fields: Array<
+  /** Specify which fields of the SEO input should be visible to editors (default: all allowed values) */
+  fields?: Array<
     'title' | 'description' | 'image' | 'no_index' | 'twitter_card'
   >;
-  /** Specify which previews should be visible to editors */
-  previews: Array<
+  /** Specify which previews should be visible to editors (default: all allowed values) */
+  previews?: Array<
     | 'google'
     | 'twitter'
     | 'slack'

--- a/packages/cma-client/src/fieldTypes/appearance/single_line.ts
+++ b/packages/cma-client/src/fieldTypes/appearance/single_line.ts
@@ -2,8 +2,8 @@
  * Simple textual input for Single-line string fields.
  */
 export type SingleLineEditorConfiguration = {
-  /** Indicates if the field should be shown bigger, as a field representing a heading */
-  heading: boolean;
+  /** Indicates if the field should be shown bigger, as a field representing a heading (default: false) */
+  heading?: boolean;
   /** A placeholder that will be shown in the editor's input to provide editors with an example */
   placeholder?: string;
 };

--- a/packages/cma-client/src/fieldTypes/appearance/structured_text.ts
+++ b/packages/cma-client/src/fieldTypes/appearance/structured_text.ts
@@ -2,20 +2,20 @@
  * Built-in editor for Structured text fields.
  */
 export type StructuredTextEditorConfiguration = {
-  /** Specify which nodes the field should allow */
-  nodes: Array<
+  /** Specify which nodes the field should allow (default: all allowed values) */
+  nodes?: Array<
     'blockquote' | 'code' | 'heading' | 'link' | 'list' | 'thematicBreak'
   >;
-  /** Specify which marks the field should allow */
-  marks: Array<
+  /** Specify which marks the field should allow (default: all allowed values) */
+  marks?: Array<
     'strong' | 'emphasis' | 'underline' | 'strikethrough' | 'code' | 'highlight'
   >;
-  /** If nodes includes "heading", specify which heading levels the field should allow (numbers between 1 and 6) */
-  heading_levels: Array<1 | 2 | 3 | 4 | 5 | 6>;
-  /** Whether you want block nodes collapsed by default or not */
+  /** If nodes includes "heading", specify which heading levels the field should allow (numbers between 1 and 6) (default: all allowed values) */
+  heading_levels?: Array<1 | 2 | 3 | 4 | 5 | 6>;
+  /** Whether you want block nodes collapsed by default or not (default: false) */
   blocks_start_collapsed?: boolean;
-  /** Whether you want to show the "Open this link in a new tab?" checkbox, that fills in the target: "_blank" meta attribute for links */
+  /** Whether you want to show the "Open this link in a new tab?" checkbox, that fills in the target: "_blank" meta attribute for links (default: true) */
   show_links_target_blank?: boolean;
-  /** Whether you want to show the complete meta editor for links */
+  /** Whether you want to show the complete meta editor for links (default: false) */
   show_links_meta_editor?: boolean;
 };

--- a/packages/cma-client/src/fieldTypes/appearance/wysiwyg.ts
+++ b/packages/cma-client/src/fieldTypes/appearance/wysiwyg.ts
@@ -2,8 +2,8 @@
  * HTML editor for Multiple-paragraph text fields.
  */
 export type WysiwygEditorConfiguration = {
-  /** Specify which buttons the toolbar should have */
-  toolbar: Array<
+  /** Specify which buttons the toolbar should have (default: ['format', 'bold', 'italic', 'strikethrough', 'ordered_list', 'unordered_list', 'quote', 'table', 'link', 'image', 'show_source', 'fullscreen']) */
+  toolbar?: Array<
     | 'format'
     | 'bold'
     | 'italic'

--- a/packages/cma-client/src/fieldTypes/validators/sanitized_html.ts
+++ b/packages/cma-client/src/fieldTypes/validators/sanitized_html.ts
@@ -3,5 +3,5 @@
  */
 export type SanitizedHtmlValidator = {
   /** Content is actively sanitized before applying the validation */
-  sanitize_before_validation: boolean;
+  sanitize_before_validation?: boolean;
 };


### PR DESCRIPTION
## Summary

Companion client update to [datocms/api#950](https://github.com/datocms/api/pull/950), which makes `appearance.parameters` keys with documented defaults truly optional on the wire and supports partial updates.

Flips the matching fields in the CMA client types to optional and documents each default in the JSDoc:

- `single_line.ts`: `heading?` (default: `false`)
- `color_picker.ts`: `enable_alpha?` (default: `false`), `preset_colors?` (default: `[]`)
- `markdown.ts`, `wysiwyg.ts`: `toolbar?` (default: full toolbar)
- `structured_text.ts`: `nodes?`, `marks?`, `heading_levels?` (default: all allowed values), plus default annotations for `blocks_start_collapsed`, `show_links_target_blank`, `show_links_meta_editor`
- `seo.ts`: `fields?`, `previews?` (default: all allowed values)
- `rich_text.ts`, `framed_single_block.ts`: default annotation for `start_collapsed`

Before this change, the client types already advertised some of these as optional, but the API rejected payloads that omitted them. After datocms/api#950 ships, omitting these keys is valid, so the types now match the wire contract.

## Test plan

- [ ] `pnpm build` succeeds
- [ ] Consumer can omit newly-optional keys without TS errors