### PR TITLE
fix: make `instanceof` reliable for ApiError, TimeoutError and CanceledPromiseError

### DIFF
--- a/packages/cma-client-browser/package.json
+++ b/packages/cma-client-browser/package.json
@@ -12,6 +12,16 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "directories": {
     "lib": "dist",
     "test": "__tests__"

--- a/packages/cma-client/package.json
+++ b/packages/cma-client/package.json
@@ -12,6 +12,17 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./resources.json": "./resources.json",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "directories": {
     "lib": "dist",

--- a/packages/cma-schema-types-generator/package.json
+++ b/packages/cma-schema-types-generator/package.json
@@ -14,6 +14,16 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "directories": {
     "lib": "dist",

--- a/packages/dashboard-client/package.json
+++ b/packages/dashboard-client/package.json
@@ -12,6 +12,17 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./resources.json": "./resources.json",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "directories": {
     "lib": "dist",

--- a/packages/rest-api-events/package.json
+++ b/packages/rest-api-events/package.json
@@ -12,6 +12,16 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "directories": {
     "lib": "dist",

--- a/packages/rest-api-reference/package.json
+++ b/packages/rest-api-reference/package.json
@@ -14,6 +14,16 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "directories": {
     "lib": "dist",

--- a/packages/rest-client-utils/package.json
+++ b/packages/rest-client-utils/package.json
@@ -12,6 +12,16 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "directories": {
     "lib": "dist",

--- a/packages/rest-client-utils/src/__tests__/errors.test.ts
+++ b/packages/rest-client-utils/src/__tests__/errors.test.ts
@@ -1,0 +1,141 @@
+import { ApiError, TimeoutError } from '../errors';
+import { CanceledPromiseError } from '../makeCancelablePromise';
+
+function buildApiError() {
+  return new ApiError({
+    request: {
+      url: '/items/bad-id',
+      method: 'GET',
+      headers: {},
+      body: undefined,
+    },
+    response: {
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      headers: {},
+      body: {
+        data: [
+          {
+            id: '1',
+            type: 'api_error' as const,
+            attributes: {
+              code: 'INVALID_FIELD',
+              doc_url: 'https://www.datocms.com/docs',
+              details: { field: 'item_id' },
+            },
+          },
+        ],
+      },
+    },
+  });
+}
+
+function buildTimeoutError() {
+  return new TimeoutError({
+    request: { url: '/items', method: 'GET', headers: {}, body: undefined },
+  });
+}
+
+describe('ApiError', () => {
+  it('keeps a correct prototype chain and name', () => {
+    const error = buildApiError();
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('ApiError');
+    expect(error.constructor.name).toBe('ApiError');
+  });
+
+  it('exposes request, response and parsed errors', () => {
+    const error = buildApiError();
+
+    expect(error.response.status).toBe(422);
+    expect(error.request.url).toBe('/items/bad-id');
+    expect(error.errors).toHaveLength(1);
+    expect(error.findError('INVALID_FIELD')).toBeTruthy();
+  });
+
+  // These packages ship parallel CJS and ESM builds, so a bundler can load two
+  // distinct copies of this module. `instanceof` must still work for an error
+  // produced by the other copy.
+  it('recognizes an instance coming from a duplicate copy of the module', () => {
+    const fromOtherCopy = Object.assign(new Error('API Error!'), {
+      name: 'ApiError',
+      [Symbol.for('@datocms/rest-client-utils:ApiError')]: true,
+    });
+
+    expect(fromOtherCopy).toBeInstanceOf(ApiError);
+  });
+
+  it('does not recognize unrelated values', () => {
+    expect(new Error('nope')).not.toBeInstanceOf(ApiError);
+    expect({}).not.toBeInstanceOf(ApiError);
+    expect(null).not.toBeInstanceOf(ApiError);
+    expect(buildTimeoutError()).not.toBeInstanceOf(ApiError);
+    // merely borrowing the name is not enough
+    expect(
+      Object.assign(new Error('impostor'), { name: 'ApiError' }),
+    ).not.toBeInstanceOf(ApiError);
+  });
+
+  it('keeps subclass checks exact', () => {
+    class SubclassedApiError extends ApiError {}
+
+    const parent = buildApiError();
+    const child = new SubclassedApiError({
+      request: { url: '/items', method: 'GET', headers: {}, body: undefined },
+      response: { status: 500, statusText: 'Error', headers: {}, body: {} },
+    });
+
+    expect(child).toBeInstanceOf(SubclassedApiError);
+    expect(child).toBeInstanceOf(ApiError);
+    expect(parent).not.toBeInstanceOf(SubclassedApiError);
+  });
+});
+
+describe('TimeoutError', () => {
+  it('keeps a correct prototype chain and name', () => {
+    const error = buildTimeoutError();
+
+    expect(error).toBeInstanceOf(TimeoutError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('TimeoutError');
+  });
+
+  it('recognizes an instance coming from a duplicate copy of the module', () => {
+    const fromOtherCopy = Object.assign(new Error('API Error!'), {
+      name: 'TimeoutError',
+      [Symbol.for('@datocms/rest-client-utils:TimeoutError')]: true,
+    });
+
+    expect(fromOtherCopy).toBeInstanceOf(TimeoutError);
+  });
+
+  it('is not confused with an ApiError', () => {
+    expect(buildApiError()).not.toBeInstanceOf(TimeoutError);
+  });
+});
+
+describe('CanceledPromiseError', () => {
+  it('keeps a correct prototype chain and name', () => {
+    const error = new CanceledPromiseError();
+
+    expect(error).toBeInstanceOf(CanceledPromiseError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('CanceledPromiseError');
+  });
+
+  it('recognizes an instance coming from a duplicate copy of the module', () => {
+    const fromOtherCopy = Object.assign(new Error('Promise canceled!'), {
+      name: 'CanceledPromiseError',
+      [Symbol.for('@datocms/rest-client-utils:CanceledPromiseError')]: true,
+    });
+
+    expect(fromOtherCopy).toBeInstanceOf(CanceledPromiseError);
+  });
+
+  it('is not confused with other error types', () => {
+    expect(buildApiError()).not.toBeInstanceOf(CanceledPromiseError);
+    expect(new Error('nope')).not.toBeInstanceOf(CanceledPromiseError);
+  });
+});

--- a/packages/rest-client-utils/src/errors.ts
+++ b/packages/rest-client-utils/src/errors.ts
@@ -59,6 +59,19 @@ export type ApiErrorResponse = {
   body?: unknown;
 };
 
+/**
+ * Brands stamped on error instances.
+ *
+ * `Symbol.for()` looks up the cross-realm global symbol registry, so every copy
+ * of this module — CJS or ESM, inlined by a bundler or not — resolves these to
+ * the very same symbols. Since these packages ship parallel CJS and ESM builds
+ * with no guarantee that a consumer ends up with a single copy, identity is
+ * carried by these brands rather than by class identity alone, so `instanceof`
+ * keeps working across duplicated copies.
+ */
+const TIMEOUT_ERROR = Symbol.for('@datocms/rest-client-utils:TimeoutError');
+const API_ERROR = Symbol.for('@datocms/rest-client-utils:ApiError');
+
 export type TimeoutErrorInitObject = {
   request: ApiErrorRequest;
   preCallStack?: string;
@@ -68,12 +81,44 @@ export class TimeoutError extends Error {
   request: ApiErrorRequest;
   preCallStack?: string;
 
+  declare readonly [TIMEOUT_ERROR]: true;
+
+  static [Symbol.hasInstance](value: unknown): value is TimeoutError {
+    if (
+      typeof value !== 'object' ||
+      value === null ||
+      !(TIMEOUT_ERROR in value)
+    ) {
+      return false;
+    }
+
+    // `this` is the constructor `instanceof` was invoked on: when it is a
+    // subclass, defer to a real prototype-chain check so subclasses stay exact.
+    // biome-ignore lint/complexity/noThisInStatic: dynamic `this` is required here; hardcoding the class would break subclass checks
+    const invokedOn = this as unknown as { prototype: object };
+
+    if (invokedOn !== TimeoutError) {
+      return Object.prototype.isPrototypeOf.call(invokedOn.prototype, value);
+    }
+
+    return true;
+  }
+
   constructor(initObject: TimeoutErrorInitObject) {
     super('API Error!');
     Object.setPrototypeOf(this, new.target.prototype);
 
+    Object.defineProperty(this, TIMEOUT_ERROR, {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+
+    this.name = 'TimeoutError';
+
     if ('captureStackTrace' in Error) {
-      Error.captureStackTrace(this, ApiError);
+      Error.captureStackTrace(this, TimeoutError);
     } else {
       this.stack = new (Error as any)().stack;
     }
@@ -100,9 +145,37 @@ export class ApiError extends Error {
   response: ApiErrorResponse;
   preCallStack?: string;
 
+  declare readonly [API_ERROR]: true;
+
+  static [Symbol.hasInstance](value: unknown): value is ApiError {
+    if (typeof value !== 'object' || value === null || !(API_ERROR in value)) {
+      return false;
+    }
+
+    // `this` is the constructor `instanceof` was invoked on: when it is a
+    // subclass, defer to a real prototype-chain check so subclasses stay exact.
+    // biome-ignore lint/complexity/noThisInStatic: dynamic `this` is required here; hardcoding the class would break subclass checks
+    const invokedOn = this as unknown as { prototype: object };
+
+    if (invokedOn !== ApiError) {
+      return Object.prototype.isPrototypeOf.call(invokedOn.prototype, value);
+    }
+
+    return true;
+  }
+
   constructor(initObject: ApiErrorInitObject) {
     super('API Error!');
     Object.setPrototypeOf(this, new.target.prototype);
+
+    Object.defineProperty(this, API_ERROR, {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+
+    this.name = 'ApiError';
 
     if ('captureStackTrace' in Error) {
       Error.captureStackTrace(this, ApiError);

--- a/packages/rest-client-utils/src/makeCancelablePromise.ts
+++ b/packages/rest-client-utils/src/makeCancelablePromise.ts
@@ -1,7 +1,48 @@
+/**
+ * See the note on the brands in `errors.ts`: identity is carried by a symbol
+ * from the cross-realm global registry so that `instanceof` keeps working even
+ * when a bundler ends up loading more than one copy of this module.
+ */
+const CANCELED_PROMISE_ERROR = Symbol.for(
+  '@datocms/rest-client-utils:CanceledPromiseError',
+);
+
 export class CanceledPromiseError extends Error {
+  declare readonly [CANCELED_PROMISE_ERROR]: true;
+
+  static [Symbol.hasInstance](value: unknown): value is CanceledPromiseError {
+    if (
+      typeof value !== 'object' ||
+      value === null ||
+      !(CANCELED_PROMISE_ERROR in value)
+    ) {
+      return false;
+    }
+
+    // `this` is the constructor `instanceof` was invoked on: when it is a
+    // subclass, defer to a real prototype-chain check so subclasses stay exact.
+    // biome-ignore lint/complexity/noThisInStatic: dynamic `this` is required here; hardcoding the class would break subclass checks
+    const invokedOn = this as unknown as { prototype: object };
+
+    if (invokedOn !== CanceledPromiseError) {
+      return Object.prototype.isPrototypeOf.call(invokedOn.prototype, value);
+    }
+
+    return true;
+  }
+
   constructor() {
     super('Promise canceled!');
     Object.setPrototypeOf(this, new.target.prototype);
+
+    Object.defineProperty(this, CANCELED_PROMISE_ERROR, {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+
+    this.name = 'CanceledPromiseError';
   }
 }
 


### PR DESCRIPTION
These packages ship parallel CJS and ESM builds, and none of them declared an `exports` map. A bundler could therefore resolve two distinct copies of the same module — and therefore two distinct `ApiError` classes — in which case `instanceof ApiError` silently returned `false` for an error thrown by the other copy:

```
bundled ApiError === handler ApiError: false
  e instanceof ApiError (bundled copy): true
  e instanceof ApiError (handler copy): false   ← the failure
  e.name                             : "Error"  ← no discriminator either
```

There was no fallback: the constructors never assigned `name`, so `e.name` was the inherited `"Error"` and could not be used to discriminate.

This fails *silently* — the guard compiles, type-narrows, and simply never matches, so an error handler looks correct while falling through to a 500.

> Companion to datocms/cda-client#6, which fixes the same class of bug on the CDA client. The cause there was different (an ES5 downlevel that broke the prototype chain outright), but the cross-copy fix is the same.

## Error identity

`ApiError`, `TimeoutError` and `CanceledPromiseError` now brand their instances with a symbol from the cross-realm global registry (`Symbol.for('@datocms/rest-client-utils:<Name>')`) and implement `static [Symbol.hasInstance]`, making `instanceof` structural rather than identity-based. The registry is shared across module copies and realms, so the check holds wherever the error came from. Subclasses fall back to a real prototype-chain check so they stay exact.

**Consumers need no code changes** — plain `instanceof` just works now.

Each constructor also sets `name` (`'ApiError'`, `'TimeoutError'`, `'CanceledPromiseError'`).

### Verification

With two genuinely separate copies of the module loaded at once:

```
distinct ApiError classes : true
distinct TimeoutError     : true

  ApiError  across copies : true   ← was false
  Timeout   across copies : true   ← was false
  Canceled  across copies : true   ← was false

  ApiError not a Timeout  : true
  plain Error rejected    : true
  names                   : ApiError, TimeoutError, CanceledPromiseError
```

11 regression tests added in `packages/rest-client-utils/src/__tests__/errors.test.ts`, covering the prototype chain, cross-copy recognition, subclass exactness, cross-type confusion, and rejection of unrelated values (including an impostor error that merely sets `name = 'ApiError'`).

## Stack trace fix

`TimeoutError`'s constructor called `Error.captureStackTrace(this, ApiError)` — the wrong constructor, so the stack was trimmed at the wrong frame. Now passes `TimeoutError`.

## Packaging

Added `exports` maps to the seven packages that lacked one, using the map already present in `cma-client-node` as the template. Their ESM builds already use `.js` specifiers and already emit a `{"type":"module"}` marker, so they are genuinely loadable — the map just makes resolution explicit instead of leaving it to each bundler's `mainFields` ordering.

The maps deliberately keep `./dist/*`, `./src/*`, `./resources.json` (where published) and `./package.json` reachable, so existing deep imports keep working:

```
  dist/cjs/errors.js -> OK
  src/errors.ts      -> OK
  package.json       -> OK
```

One caveat: `exports` targets don't get Node's extension guessing, so a deep import must now spell out the extension (`.../errors.js`, not `.../errors`).

`cma-client-analysis` and `cma-client-node` already had maps and are untouched.

## Testing notes

`npx biome ci packages` is clean and `npm run build` succeeds for all 9 packages. I ran the new `errors.test.ts` suite (11 passing) but **not** the full `npm test`, since the rest of the suite provisions and deletes real DatoCMS projects against a live account — worth a CI run before merging.

## Release note

Worth shipping as a **minor**, not a patch: the `exports` maps change resolution.
