### PR TITLE
feat(release): one v-tag per release, carrying the GitHub release notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,3 +91,10 @@ detects the release commit, skips straight to publishing, and `changeset publish
 only pushes the packages that aren't on the registry yet. Never "clean up" a
 failed release by deleting tags or force-pushing — that is exactly the bug this
 process was built to eliminate.
+
+`changeset publish` runs with `--no-git-tag`: it would otherwise tag all nine
+packages separately, and they move in lockstep, so the script creates the single
+`vX.Y.Z` tag this repo has always used — after the publish, so a partial release
+leaves no tag at all. The tag then carries a GitHub release whose body is built
+from the `CHANGELOG.md`s: a section per package that has something to say, and a
+footer listing everything that shipped at that version.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ npm run publish
 ```
 
 The script refuses to start unless you're on an up-to-date `main`, with a clean
-tree and logged in to npm. It then builds and runs the whole test suite *before*
-touching anything, applies the pending changesets, commits the release, pushes
-to npm, and only then tags and pushes to GitHub.
+tree and logged in to both npm and GitHub (`gh auth login`). It then builds and
+runs the whole test suite *before* touching anything, applies the pending
+changesets, commits the release, pushes to npm, and only then tags `vX.Y.Z`,
+pushes, and publishes the GitHub release — whose notes are the changelog entries
+changesets just wrote. It prints the link to it when it's done.
 
 If it fails partway through, there is nothing to undo: run it again and it will
 resume the publish where it stopped.

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -30,6 +30,61 @@ pkg_version() { node -p "require('./packages/$1/package.json').version"; }
 pending_changesets() { find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' '; }
 is_published() { npm view "@datocms/cma-client@$1" version >/dev/null 2>&1; }
 
+# Every publishable workspace package, as "name version location" triples.
+#
+# Read off the filesystem rather than asked of npm: `npm query` resolves
+# workspace locations through node_modules, which during a release rehearsal is
+# a symlink to another checkout, so it answers with paths outside the copy you
+# are actually rehearsing.
+packages() {
+  node -e '
+    const fs = require("node:fs"), path = require("node:path");
+    for (const pattern of require("./package.json").workspaces) {
+      const dir = path.dirname(pattern);
+      for (const entry of fs.readdirSync(dir).sort()) {
+        const location = path.join(dir, entry);
+        let pkg;
+        try { pkg = JSON.parse(fs.readFileSync(path.join(location, "package.json"), "utf8")); } catch { continue; }
+        if (pkg.private) continue;
+        console.log(pkg.name, pkg.version, location);
+      }
+    }
+  '
+}
+
+# The section of a package's CHANGELOG for one version, without its "## x.y.z"
+# heading — changesets has already written exactly the prose we want.
+changelog_section() { # $1 = package location, $2 = version
+  awk -v want="## $2" '$0 == want { found = 1; next } found && /^## / { exit } found' "$1/CHANGELOG.md"
+}
+
+# True when a changelog section says something a human wrote, as opposed to the
+# dependency bookkeeping every package in a fixed group accumulates:
+#
+#     - Updated dependencies [1a2b3c4]
+#       - @datocms/cma-client@5.9.0
+#
+# A bullet counts as prose unless it is exactly one of those lines.
+has_prose() {
+  grep -vE '^- Updated dependencies( \[[0-9a-f]+\])?$|^ *- [^ ]+@[0-9][^ ]*$' <<<"$1" | grep -qE '^- '
+}
+
+# The body of the GitHub release. All nine packages move in lockstep, so one
+# release covers them all — but only the ones with something to say get a
+# section, or the page fills up with each package restating that the others
+# moved too. The footer keeps every published package visible.
+release_notes() {
+  local name ver loc section shipped=""
+  while read -r name ver loc; do
+    shipped="$shipped
+- $name@$ver"
+    section="$(changelog_section "$loc" "$VERSION")"
+    has_prose "$section" || continue
+    printf '## %s\n%s\n\n' "$name" "$section"
+  done < <(packages)
+  printf -- '---\n\nReleased in lockstep:%s\n' "$shipped"
+}
+
 # ---------------------------------------------------------------------------
 # Preflight: no mutations, just refuse to start from a state we can't finish.
 # ---------------------------------------------------------------------------
@@ -43,6 +98,9 @@ git fetch --quiet origin main
   fail "main and origin/main have diverged. Pull (or push) first."
 
 npm whoami >/dev/null 2>&1 || fail "you are not logged in to npm. Run 'npm login'."
+
+command -v gh >/dev/null 2>&1 || fail "the GitHub CLI is not installed, so the release notes can't be published."
+gh auth status >/dev/null 2>&1 || fail "you are not logged in to GitHub. Run 'gh auth login'."
 
 echo "on main, in sync with origin, npm user: $(npm whoami)"
 
@@ -101,20 +159,55 @@ fi
 VERSION="$(pkg_version cma-client)"
 
 # ---------------------------------------------------------------------------
-# The irreversible step. npm first; changeset creates the git tags only for the
-# packages it actually managed to publish.
+# The irreversible step, npm first.
+#
+# --no-git-tag: changesets would tag all nine packages separately
+# (@datocms/cma-client@5.9.0, @datocms/dashboard-client@5.9.0, ...). They move in
+# lockstep, so those tags all point at the same commit and say the same thing,
+# and this repo has tagged `vX.Y.Z` for its whole history. We tag once, below.
+# Tagging after the publish keeps the property that matters: a tag can only
+# exist for a version that is actually on the registry.
 # ---------------------------------------------------------------------------
 step "Publishing v$VERSION to npm"
 if [ -n "$DIST_TAG" ]; then
-  npx changeset publish --tag "$DIST_TAG"
+  npx changeset publish --no-git-tag --tag "$DIST_TAG"
 else
-  npx changeset publish
+  npx changeset publish --no-git-tag
 fi
 
 # ---------------------------------------------------------------------------
 # git follows npm.
 # ---------------------------------------------------------------------------
+step "Tagging v$VERSION"
+if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+  echo "v$VERSION already tagged"
+else
+  git tag -a "v$VERSION" -m "v$VERSION"
+fi
+
 step "Pushing to GitHub"
 git push --follow-tags origin main
 
+# ---------------------------------------------------------------------------
+# The release notes. Last, because it's the only step a human can redo by hand
+# from the changelog if it goes wrong.
+# ---------------------------------------------------------------------------
+step "Publishing the release notes"
+if gh release view "v$VERSION" >/dev/null 2>&1; then
+  echo "the v$VERSION release already exists, leaving it alone"
+else
+  # A prerelease must not become the repo's "Latest release": that's reserved
+  # for whatever is on the `latest` dist-tag.
+  PRERELEASE=""
+  case "$VERSION" in *-*) PRERELEASE="--prerelease" ;; esac
+  [ -z "$DIST_TAG" ] || PRERELEASE="--prerelease"
+
+  release_notes | gh release create "v$VERSION" --title "v$VERSION" --notes-file - $PRERELEASE
+fi
+
+# Asked for rather than parsed out of `gh release create`, so the link is the
+# same whether we just created the release or found one already there.
+RELEASE_URL="$(gh release view "v$VERSION" --json url --jq .url 2>/dev/null || true)"
+
 printf '\n\033[32mReleased v%s\033[0m\n' "$VERSION"
+[ -z "$RELEASE_URL" ] || printf '%s\n' "$RELEASE_URL"

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -28,7 +28,6 @@ fail() { printf '\n\033[31mAborted: %s\033[0m\n' "$1" >&2; exit 1; }
 
 pkg_version() { node -p "require('./packages/$1/package.json').version"; }
 pending_changesets() { find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' '; }
-is_published() { npm view "@datocms/cma-client@$1" version >/dev/null 2>&1; }
 
 # Every publishable workspace package, as "name version location" triples.
 #
@@ -50,6 +49,18 @@ packages() {
       }
     }
   '
+}
+
+# The resume condition: every package whose local version is not yet on the
+# registry. Asking about a single package would be wrong — the nine publish one
+# after another, so a run that dies partway leaves some of them on npm and the
+# rest not, and "is cma-client published?" then answers "nothing to do".
+unpublished() {
+  local name ver loc missing=""
+  while read -r name ver loc; do
+    npm view "$name@$ver" version >/dev/null 2>&1 || missing="$missing $name@$ver"
+  done < <(packages)
+  echo "${missing# }"
 }
 
 # The section of a package's CHANGELOG for one version, without its "## x.y.z"
@@ -110,11 +121,11 @@ echo "on main, in sync with origin, npm user: $(npm whoami)"
 CURRENT="$(pkg_version cma-client)"
 
 if [ "$(pending_changesets)" -eq 0 ]; then
-  if is_published "$CURRENT"; then
-    fail "no pending changesets: there is nothing to release.
+  MISSING="$(unpublished)"
+  [ -n "$MISSING" ] || fail "no pending changesets: there is nothing to release.
   Describe your changes with 'npx changeset' first."
-  fi
   step "Resuming the interrupted release of v$CURRENT"
+  echo "still missing from npm:$(printf ' %s' $MISSING)"
   RESUMING=1
 else
   RESUMING=0
@@ -142,7 +153,7 @@ if [ "$RESUMING" -eq 0 ]; then
   [ "$NEXT" != "$CURRENT" ] || fail "changeset version did not bump anything."
   echo "$CURRENT -> $NEXT"
 
-  is_published "$NEXT" && fail "version $NEXT is already on npm. Aborting before overwriting anything."
+  [ -n "$(unpublished)" ] || fail "version $NEXT is already on npm. Aborting before overwriting anything."
 
   step "Stamping the client version and refreshing the lockfile"
   ./generate/setClientVersion.ts


### PR DESCRIPTION
Backport of datocms/plugins-sdk#49 and datocms/plugins-sdk#50. It lands here
**before** the first changesets release rather than after one, so there's
nothing to patch up afterwards.

## The tag

`changeset publish` tags every package separately. Here that's **nine tags per
release** — `@datocms/cma-client@5.9.0`, `@datocms/dashboard-client@5.9.0`, … —
all pointing at the same commit and all saying the same thing, because the
`@datocms/*` packages are a `fixed` group. It also means the `vX.Y.Z` tag this
repo has used for its entire history (every one of its tags is `vX.Y.Z`) would
have silently stopped being created at the next release.

So `changeset publish` now runs with `--no-git-tag`, and the script creates
`vX.Y.Z` itself, right after the publish returns.

That doesn't weaken the ordering invariant this script was built around, it
tightens it: a tag can still only exist for a version that is actually on the
registry, and a **partial** publish now leaves no tag at all instead of one tag
per package that made it through.

## The release notes

Only **5 tags** here ever got a GitHub release, and the most recent one
(`v5.7.0`) is still a draft — because writing one meant composing it by hand.
Changesets now writes exactly that prose into the `CHANGELOG.md`s.

With nine lockstep packages, posting every section verbatim gives **46 lines of
release notes carrying one line of actual content**: each package's changelog
dutifully records that the other eight moved. So a section is included only if
it has a bullet that is neither `Updated dependencies` nor a bare `pkg@version`,
and a footer lists everything that shipped, so a package with no prose of its
own doesn't vanish from the notes.

Run against a real `changeset version` rehearsal of this repo (a single `minor`
changeset on `@datocms/cma-client`), that's 46 lines down to 22:

```
## @datocms/cma-client

### Minor Changes

- Rehearsal: a change that touches only one package.

### Patch Changes

- @datocms/rest-client-utils@5.9.0

---

Released in lockstep:
- @datocms/cma-client@5.9.0
- @datocms/cma-client-analysis@5.9.0
- @datocms/cma-client-browser@5.9.0
- @datocms/cma-client-node@5.9.0
- @datocms/cma-schema-types-generator@5.9.0
- @datocms/dashboard-client@5.9.0
- @datocms/rest-api-events@5.9.0
- @datocms/rest-api-reference@5.9.0
- @datocms/rest-client-utils@5.9.0
```

A prerelease is marked `--prerelease`, so a `publish-next` can't take over the
repository's "Latest release" badge. The script prints the release URL when it
finishes.

## Preflight

`gh` and its auth are now checked next to `npm whoami`, so a missing GitHub CLI
stops the release before anything is mutated rather than after npm has already
been published to.

## How this was verified

- **`--no-git-tag` suppresses every tag, not just some.** Read from the installed
  source: `@changesets/cli/dist/publish.mjs:94` guards the `tag-only` path and
  `:188` the successful-publish path, both with the same
  `options?.gitTag ?? true`. With the flag off, `gitTagReleases` stays empty.
- **The flag parses and composes with `--tag`** — replayed the CLI's own option
  declaration through cac with `--no-git-tag --tag next`.
- **The release notes are real output**, from a `changeset version` rehearsal on
  a scratch copy of this repo (the block above).
- **`gh release create --notes-file -` reads stdin**, and the whole
  tag→push→release path was exercised for real in `plugins-sdk` when
  [v2.2.7](https://github.com/datocms/plugins-sdk/releases/tag/v2.2.7) was
  backfilled with these same helpers.

**Not verified here:** the script has not been run end to end in this repo — the
next release will be its first run.

## The resume check, which was wrong here

Included in this PR rather than left for later, because the tag change makes it
more visible: with `--no-git-tag` there is no per-package tag to tell you how far
a failed publish got.

The check asked whether `@datocms/cma-client` was on the registry. The nine
packages publish one after another, so a run that dies partway leaves some on
npm and the rest not — and if cma-client was among the ones that made it, the
script reports "nothing to release" for a release that is half done. The only
way out was publishing the stragglers by hand, which is exactly the class of
problem this script exists to remove.

It now asks *which* packages are missing and resumes if that list isn't empty,
printing it so you can see what's left.

Verified against the real registry:

| state | old check | new check |
|---|---|---|
| all nine at `5.8.0`, published | nothing to release | nothing to release |
| cma-client at `5.8.0`, three siblings at an unpublished version | **"nothing to release"** ✗ | names all three ✓ |