### PR TITLE
feat(cma-client)!: one `default_field_metadata` shape, whatever the environment does

### DIFF
--- a/.changeset/olive-donkeys-hear.md
+++ b/.changeset/olive-donkeys-hear.md
@@ -1,0 +1,47 @@
+---
+"@datocms/cma-client": major
+---
+
+The `uploads` simple methods now speak one `default_field_metadata` shape, whatever the environment does
+
+`default_field_metadata` travels in two shapes: field-keyed
+(`{ alt: { en } }`) on environments where the
+[non-localized focal points](https://www.datocms.com/product-updates/non-localized-focal-points)
+opt-in is active, locale-keyed (`{ en: { alt } }`) where it isn't. Which one
+applies is a per-environment setting, not a version — projects created before
+the opt-in keep the legacy shape until their owner activates it, and each
+environment rejects the other shape with `422 INVALID_FORMAT`.
+
+The types describe the field-keyed shape only, at both layers. On a legacy
+environment that left no way through: the correctly typed call failed at
+runtime, and the call the API accepted didn't compile.
+
+`uploads.create`, `update`, `find`, `list` and `listPagedIterator` now convert
+in both directions, so you always read and write the field-keyed shape the
+types describe. `createFromUrl`, `createFromLocalFile`, `updateFromUrl` and
+`updateFromLocalFile` go through them and are covered too.
+
+**The raw methods are unchanged and still hand you what the environment sends,
+in whichever shape it sends it.** That is the point of the raw layer, and
+`UploadLocaleKeyedDefaultFieldMetadata` /
+`UploadLocaleKeyedDefaultFieldMetadataInRequest` are still exported for typing
+those payloads.
+
+Reads need no lookup — the two shapes are told apart structurally. Writes ask
+the environment which shape it speaks, through a `site` fetch memoized per
+client for twenty minutes and shared by concurrent callers, so a batch of ten
+thousand uploads costs one extra request rather than ten thousand. A client
+that never writes asset metadata never makes it at all.
+
+### Breaking
+
+On an environment **without** the opt-in, the simple methods used to hand back
+the locale-keyed payload as the API sent it, and the docs on
+`UploadLocaleKeyedDefaultFieldMetadata` told you to cast the response to read
+it. They now return the field-keyed shape instead, so code doing
+`upload.default_field_metadata.en.alt` reads `undefined` — silently. Read it as
+`upload.default_field_metadata.alt.en`, which is what the types said all along,
+or move to `rawFind` / `rawList` to keep seeing the wire payload.
+
+Opted-in environments are unaffected: they already spoke the field-keyed shape,
+and nothing about those responses changes.

--- a/packages/cma-client-node/__tests__/uploadDefaultFieldMetadata.test.ts
+++ b/packages/cma-client-node/__tests__/uploadDefaultFieldMetadata.test.ts
@@ -1,0 +1,98 @@
+import { generateNewCmaClient } from '../../../jest-helpers/generateNewCmaClient';
+
+describe('upload default_field_metadata', () => {
+  it.concurrent('round-trips the field-keyed shape', async () => {
+    const client = await generateNewCmaClient();
+
+    await client.site.update({ locales: ['en', 'it'] });
+
+    const upload = await client.uploads.createFromUrl({
+      url: 'https://www.datocms-assets.com/205/1525789775-dato.png',
+      default_field_metadata: {
+        alt: { en: 'An alt', it: 'Un alt' },
+        title: { en: 'A title', it: 'Un titolo' },
+        focal_point: { x: 0.3, y: 0.6 },
+      },
+    });
+
+    expect(upload.default_field_metadata.alt).toEqual({
+      en: 'An alt',
+      it: 'Un alt',
+    });
+    expect(upload.default_field_metadata.focal_point).toEqual({
+      x: 0.3,
+      y: 0.6,
+    });
+
+    const updated = await client.uploads.update(upload.id, {
+      default_field_metadata: { alt: { en: 'A new alt' } },
+    });
+
+    // A partial patch leaves the untouched keys alone
+    expect(updated.default_field_metadata.alt).toEqual({
+      en: 'A new alt',
+      it: 'Un alt',
+    });
+    expect(updated.default_field_metadata.title).toEqual({
+      en: 'A title',
+      it: 'Un titolo',
+    });
+
+    const found = await client.uploads.find(upload.id);
+    expect(found.default_field_metadata).toEqual(
+      updated.default_field_metadata,
+    );
+
+    const [listed] = await client.uploads.list();
+    expect(listed!.default_field_metadata).toEqual(
+      updated.default_field_metadata,
+    );
+  });
+
+  it.concurrent('looks the environment up once for a batch', async () => {
+    const client = await generateNewCmaClient();
+
+    const upload = await client.uploads.createFromUrl({
+      url: 'https://www.datocms-assets.com/205/1525789775-dato.png',
+    });
+
+    const siteFind = jest.spyOn(client.site, 'find');
+
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        client.uploads.update(upload.id, {
+          default_field_metadata: { alt: { en: `Alt ${i}` } },
+        }),
+      ),
+    );
+
+    expect(siteFind).toHaveBeenCalledTimes(1);
+
+    // And the cached answer still serves later writes
+    await client.uploads.update(upload.id, {
+      default_field_metadata: { alt: { en: 'Last alt' } },
+    });
+
+    expect(siteFind).toHaveBeenCalledTimes(1);
+
+    siteFind.mockRestore();
+  });
+
+  it.concurrent('asks nothing when no metadata is written', async () => {
+    const client = await generateNewCmaClient();
+
+    const upload = await client.uploads.createFromUrl({
+      url: 'https://www.datocms-assets.com/205/1525789775-dato.png',
+    });
+
+    const siteFind = jest.spyOn(client.site, 'find');
+
+    await client.uploads.update(upload.id, { author: 'Someone' });
+    await client.uploads.find(upload.id);
+    await client.uploads.list();
+
+    expect(siteFind).not.toHaveBeenCalled();
+
+    siteFind.mockRestore();
+  });
+});

--- a/packages/cma-client/__tests__/defaultFieldMetadataShapes.test.ts
+++ b/packages/cma-client/__tests__/defaultFieldMetadataShapes.test.ts
@@ -1,0 +1,76 @@
+import {
+  fromLocaleKeyed,
+  isFieldKeyed,
+  toLocaleKeyed,
+} from '../src/utilities/defaultFieldMetadata';
+
+describe('telling the two shapes apart', () => {
+  it('reads a top-level focal_point as field-keyed', () => {
+    expect(
+      isFieldKeyed({
+        alt: { en: 'An alt' },
+        title: { en: null },
+        custom_data: { en: {} },
+        focal_point: null,
+        poster_time: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('reads locale entries as locale-keyed', () => {
+    expect(
+      isFieldKeyed({
+        en: {
+          alt: 'An alt',
+          title: null,
+          custom_data: {},
+          focal_point: null,
+          poster_time: null,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('is not fooled by a locale that looks like a field name', () => {
+    // `alt` matches the API's language-code pattern, so a project could have a
+    // locale called that; `focal_point` cannot, which is why it is the
+    // discriminator and `alt` is not
+    expect(
+      isFieldKeyed({
+        alt: {
+          alt: 'An alt',
+          title: null,
+          custom_data: {},
+          focal_point: null,
+          poster_time: null,
+        },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('converting between the shapes', () => {
+  it('round-trips a fully populated payload', () => {
+    const fieldKeyed = {
+      alt: { en: 'An alt', it: 'Un alt' },
+      title: { en: 'A title', it: 'Un titolo' },
+      custom_data: { en: {}, it: {} },
+      focal_point: { x: 0.3, y: 0.6 },
+      poster_time: 12.5,
+    };
+
+    expect(
+      fromLocaleKeyed(toLocaleKeyed(fieldKeyed, ['en', 'it']) as never),
+    ).toEqual(fieldKeyed);
+  });
+
+  it('survives an empty locale-keyed payload', () => {
+    expect(fromLocaleKeyed({})).toEqual({
+      alt: {},
+      title: {},
+      custom_data: {},
+      focal_point: null,
+      poster_time: null,
+    });
+  });
+});

--- a/packages/cma-client/__tests__/environmentSettings.test.ts
+++ b/packages/cma-client/__tests__/environmentSettings.test.ts
@@ -1,0 +1,122 @@
+import type { Client } from '../src/generated/Client';
+import {
+  type EnvironmentFlag,
+  fetchEnvironmentSettings,
+  isEnvironmentFlagActive,
+} from '../src/utilities/environmentSettings';
+
+function buildClient(meta: Record<string, unknown>, locales = ['en']) {
+  const find = jest.fn(async () => ({ locales, meta }));
+
+  return { client: { site: { find } } as unknown as Client, find };
+}
+
+describe('environment settings', () => {
+  it('derives the flag names from the generated meta type', () => {
+    // Every boolean in `site.meta` is a flag, whether it is a product-update
+    // opt-in or plain state...
+    const flags: EnvironmentFlag[] = [
+      'non_localized_focal_points',
+      'milliseconds_in_datetime',
+      'draft_mode_default',
+      'improved_exposure_of_inline_blocks_in_cda',
+      'custom_upload_storage_settings',
+      'allow_custom_theme',
+    ];
+
+    expect(flags).toHaveLength(6);
+
+    // ...and nothing else is: `created_at` is a string, `nope` isn't there
+    // @ts-expect-error
+    const notAFlag: EnvironmentFlag = 'created_at';
+    // @ts-expect-error
+    const neitherIsThis: EnvironmentFlag = 'nope';
+
+    expect([notAFlag, neitherIsThis]).toBeTruthy();
+  });
+
+  it('reports an active flag', async () => {
+    const { client } = buildClient({ milliseconds_in_datetime: true });
+
+    await expect(
+      isEnvironmentFlagActive(client, 'milliseconds_in_datetime'),
+    ).resolves.toBe(true);
+  });
+
+  it('treats an absent flag as inactive', async () => {
+    const { client } = buildClient({});
+
+    await expect(
+      isEnvironmentFlagActive(client, 'non_localized_focal_points'),
+    ).resolves.toBe(false);
+  });
+
+  it('answers about several flags with a single lookup', async () => {
+    const { client, find } = buildClient({
+      improved_items_listing: true,
+      milliseconds_in_datetime: false,
+    });
+
+    await Promise.all([
+      isEnvironmentFlagActive(client, 'improved_items_listing'),
+      isEnvironmentFlagActive(client, 'milliseconds_in_datetime'),
+      fetchEnvironmentSettings(client),
+    ]);
+
+    expect(find).toHaveBeenCalledTimes(1);
+  });
+
+  it('picks up an activation once the cached site expires', async () => {
+    const { client, find } = buildClient({ improved_boolean_fields: false });
+
+    await expect(
+      isEnvironmentFlagActive(client, 'improved_boolean_fields'),
+    ).resolves.toBe(false);
+
+    find.mockResolvedValue({
+      locales: ['en'],
+      meta: { improved_boolean_fields: true },
+    });
+
+    // Still cached, so the activation is not seen yet
+    await expect(
+      isEnvironmentFlagActive(client, 'improved_boolean_fields'),
+    ).resolves.toBe(false);
+    expect(find).toHaveBeenCalledTimes(1);
+
+    const realNow = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(realNow + 21 * 60 * 1000);
+
+    await expect(
+      isEnvironmentFlagActive(client, 'improved_boolean_fields'),
+    ).resolves.toBe(true);
+    expect(find).toHaveBeenCalledTimes(2);
+
+    jest.spyOn(Date, 'now').mockRestore();
+  });
+
+  it('keeps a cache per client', async () => {
+    const first = buildClient({ improved_items_listing: true });
+    const second = buildClient({ improved_items_listing: false });
+
+    await expect(
+      isEnvironmentFlagActive(first.client, 'improved_items_listing'),
+    ).resolves.toBe(true);
+    await expect(
+      isEnvironmentFlagActive(second.client, 'improved_items_listing'),
+    ).resolves.toBe(false);
+  });
+
+  it('does not cache a failed lookup', async () => {
+    const { client, find } = buildClient({ improved_items_listing: true });
+
+    find.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(fetchEnvironmentSettings(client)).rejects.toThrow('boom');
+    await expect(
+      isEnvironmentFlagActive(client, 'improved_items_listing'),
+    ).resolves.toBe(true);
+
+    expect(find).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/cma-client/__tests__/uploadDefaultFieldMetadata.test.ts
+++ b/packages/cma-client/__tests__/uploadDefaultFieldMetadata.test.ts
@@ -1,0 +1,204 @@
+import type { Client } from '../src/generated/Client';
+import UploadResource from '../src/resources/Upload';
+
+type SiteStub = {
+  locales: string[];
+  meta?: { non_localized_focal_points?: boolean };
+};
+
+function buildResource(site: SiteStub, upload: Record<string, unknown> = {}) {
+  const find = jest.fn(async () => site);
+
+  const entity = {
+    id: 'aaa',
+    type: 'upload',
+    attributes: { path: '/img.png', ...upload },
+  };
+
+  const request = jest.fn(async ({ url }: { url: string }) => ({
+    // `/uploads` is the collection endpoint; everything else is a single entity
+    data: url === '/uploads' ? [entity] : entity,
+  }));
+
+  const client = { site: { find }, request } as unknown as Client;
+
+  return { uploads: new UploadResource(client), find, request };
+}
+
+function sentAttributes(request: jest.Mock) {
+  return (request.mock.calls[0]?.[0] as { body: { data: { attributes: any } } })
+    .body.data.attributes;
+}
+
+const fieldKeyedMetadata = {
+  alt: { en: 'An alt', it: 'Un alt' },
+  title: { en: 'A title', it: 'Un titolo' },
+  focal_point: { x: 0.3, y: 0.6 },
+};
+
+describe('default_field_metadata wire shape', () => {
+  describe('on an environment with the opt-in active', () => {
+    const site: SiteStub = {
+      locales: ['en', 'it'],
+      meta: { non_localized_focal_points: true },
+    };
+
+    it('sends the field-keyed payload untouched', async () => {
+      const { uploads, request } = buildResource(site);
+
+      await uploads.update('aaa', {
+        default_field_metadata: fieldKeyedMetadata,
+      });
+
+      expect(sentAttributes(request).default_field_metadata).toEqual(
+        fieldKeyedMetadata,
+      );
+    });
+
+    it('leaves a field-keyed response untouched', async () => {
+      const { uploads } = buildResource(site, {
+        default_field_metadata: {
+          alt: { en: 'An alt' },
+          title: { en: null },
+          custom_data: { en: {} },
+          focal_point: { x: 0.3, y: 0.6 },
+          poster_time: null,
+        },
+      });
+
+      const upload = await uploads.find('aaa');
+
+      expect(upload.default_field_metadata.alt).toEqual({ en: 'An alt' });
+      expect(upload.default_field_metadata.focal_point).toEqual({
+        x: 0.3,
+        y: 0.6,
+      });
+    });
+  });
+
+  describe('on an environment with the opt-in inactive', () => {
+    const site: SiteStub = {
+      locales: ['en', 'it'],
+      meta: { non_localized_focal_points: false },
+    };
+
+    it('pivots the payload to the locale-keyed shape', async () => {
+      const { uploads, request } = buildResource(site);
+
+      await uploads.update('aaa', {
+        default_field_metadata: fieldKeyedMetadata,
+      });
+
+      expect(sentAttributes(request).default_field_metadata).toEqual({
+        en: {
+          alt: 'An alt',
+          title: 'A title',
+          focal_point: { x: 0.3, y: 0.6 },
+        },
+        it: { alt: 'Un alt', title: 'Un titolo' },
+      });
+    });
+
+    it('writes a lone focal_point on the environment first locale', async () => {
+      const { uploads, request } = buildResource(site);
+
+      await uploads.update('aaa', {
+        default_field_metadata: { focal_point: { x: 0.1, y: 0.2 } },
+      });
+
+      expect(sentAttributes(request).default_field_metadata).toEqual({
+        en: { focal_point: { x: 0.1, y: 0.2 } },
+      });
+    });
+
+    it('normalizes a locale-keyed response to the field-keyed shape', async () => {
+      const { uploads } = buildResource(site, {
+        default_field_metadata: {
+          en: {
+            alt: 'An alt',
+            title: null,
+            custom_data: {},
+            focal_point: { x: 0.3, y: 0.6 },
+            poster_time: 12.5,
+          },
+          it: {
+            alt: 'Un alt',
+            title: null,
+            custom_data: {},
+            focal_point: { x: 0.3, y: 0.6 },
+            poster_time: 12.5,
+          },
+        },
+      });
+
+      const upload = await uploads.find('aaa');
+
+      expect(upload.default_field_metadata).toEqual({
+        alt: { en: 'An alt', it: 'Un alt' },
+        title: { en: null, it: null },
+        custom_data: { en: {}, it: {} },
+        focal_point: { x: 0.3, y: 0.6 },
+        poster_time: 12.5,
+      });
+    });
+
+    it('treats a missing opt-in flag as inactive', async () => {
+      const { uploads, request } = buildResource({ locales: ['en'], meta: {} });
+
+      await uploads.update('aaa', {
+        default_field_metadata: { alt: { en: 'An alt' } },
+      });
+
+      expect(sentAttributes(request).default_field_metadata).toEqual({
+        en: { alt: 'An alt' },
+      });
+    });
+  });
+
+  describe('the environment lookup', () => {
+    const site: SiteStub = {
+      locales: ['en'],
+      meta: { non_localized_focal_points: false },
+    };
+
+    it('runs once for a whole batch of concurrent writes', async () => {
+      const { uploads, find } = buildResource(site);
+
+      await Promise.all(
+        Array.from({ length: 500 }, (_, i) =>
+          uploads.update('aaa', {
+            default_field_metadata: { alt: { en: `Alt ${i}` } },
+          }),
+        ),
+      );
+
+      expect(find).toHaveBeenCalledTimes(1);
+    });
+
+    it('never runs for writes that carry no metadata', async () => {
+      const { uploads, find } = buildResource(site);
+
+      await uploads.update('aaa', { author: 'Someone' });
+      await uploads.find('aaa');
+      await uploads.list();
+
+      expect(find).not.toHaveBeenCalled();
+    });
+
+    it('is not poisoned by a failed lookup', async () => {
+      const { uploads, find } = buildResource(site);
+
+      find.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        uploads.update('aaa', { default_field_metadata: { alt: { en: 'x' } } }),
+      ).rejects.toThrow('boom');
+
+      await uploads.update('aaa', {
+        default_field_metadata: { alt: { en: 'x' } },
+      });
+
+      expect(find).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/cma-client/src/index.ts
+++ b/packages/cma-client/src/index.ts
@@ -7,7 +7,7 @@ export * as Resources from './generated/resources/index.js';
 export type {
   UploadLocaleKeyedDefaultFieldMetadata,
   UploadLocaleKeyedDefaultFieldMetadataInRequest,
-} from './resources/Upload.js';
+} from './utilities/defaultFieldMetadata.js';
 export * from './utilities/buildBlockRecord.js';
 export * from './utilities/duplicateBlockRecord.js';
 export * from './utilities/fieldsContainingReferences.js';

--- a/packages/cma-client/src/resources/Upload.ts
+++ b/packages/cma-client/src/resources/Upload.ts
@@ -1,38 +1,94 @@
+import type * as ApiTypes from '../generated/ApiTypes.js';
 import BaseUpload from '../generated/resources/Upload.js';
+import {
+  encodeDefaultFieldMetadata,
+  normalizeUpload,
+} from '../utilities/defaultFieldMetadata.js';
 
 /**
- * Legacy locale-keyed shape of an upload's `default_field_metadata`, as
- * returned and accepted by environments where the `non_localized_focal_points`
- * opt-in is inactive.
+ * `default_field_metadata` travels in one of two shapes, and which one an
+ * environment speaks depends on the `non_localized_focal_points` opt-in — each
+ * rejects the other with `422 INVALID_FORMAT`. This resource hides that: you
+ * always read and write the field-keyed shape the types describe, and the
+ * legacy one is converted to and from as needed.
  *
- * The generated `Upload.default_field_metadata` type reflects the new
- * field-keyed shape (the path forward). This type is provided so consumers
- * targeting opted-out environments during the transition can cast the
- * response value to a structurally accurate shape.
+ * The raw methods are deliberately left alone: they are the escape hatch for
+ * anyone who needs to see what actually goes over the wire.
  */
-export type UploadLocaleKeyedDefaultFieldMetadata = {
-  [localeCode: string]: {
-    alt: string | null;
-    title: string | null;
-    custom_data: { [k: string]: unknown };
-    focal_point: { x: number; y: number } | null;
-    poster_time: number | null;
-  };
-};
+export default class UploadResource extends BaseUpload {
+  /**
+   * Create a new upload
+   *
+   * Read more: https://www.datocms.com/docs/content-management-api/resources/upload/create
+   *
+   * @throws {ApiError}
+   * @throws {TimeoutError}
+   */
+  async create(body: ApiTypes.UploadCreateSchema) {
+    return normalizeUpload(
+      await super.create(await encodeDefaultFieldMetadata(this.client, body)),
+    );
+  }
 
-/**
- * Legacy locale-keyed shape accepted on `create` / `update` request bodies
- * by environments where the `non_localized_focal_points` opt-in is inactive.
- * All fields are optional, matching the partial-write contract.
- */
-export type UploadLocaleKeyedDefaultFieldMetadataInRequest = {
-  [localeCode: string]: {
-    alt?: string | null;
-    title?: string | null;
-    custom_data?: { [k: string]: unknown };
-    focal_point?: { x: number; y: number } | null;
-    poster_time?: number | null;
-  };
-};
+  /**
+   * Update an upload
+   *
+   * Read more: https://www.datocms.com/docs/content-management-api/resources/upload/update
+   *
+   * @throws {ApiError}
+   * @throws {TimeoutError}
+   */
+  async update(
+    uploadId: string | ApiTypes.UploadData,
+    body: ApiTypes.UploadUpdateSchema,
+    queryParams?: ApiTypes.UploadUpdateHrefSchema,
+  ) {
+    return normalizeUpload(
+      await super.update(
+        uploadId,
+        await encodeDefaultFieldMetadata(this.client, body),
+        queryParams,
+      ),
+    );
+  }
 
-export default class UploadResource extends BaseUpload {}
+  /**
+   * Retrieve an upload
+   *
+   * Read more: https://www.datocms.com/docs/content-management-api/resources/upload/self
+   *
+   * @throws {ApiError}
+   * @throws {TimeoutError}
+   */
+  async find(uploadId: string | ApiTypes.UploadData) {
+    return normalizeUpload(await super.find(uploadId));
+  }
+
+  /**
+   * List all uploads
+   *
+   * Read more: https://www.datocms.com/docs/content-management-api/resources/upload/instances
+   *
+   * @throws {ApiError}
+   * @throws {TimeoutError}
+   */
+  async list(queryParams?: ApiTypes.UploadInstancesHrefSchema) {
+    return (await super.list(queryParams)).map(normalizeUpload);
+  }
+
+  /**
+   * Async iterator to auto-paginate over elements returned by list()
+   *
+   * Read more: https://www.datocms.com/docs/content-management-api/resources/upload/instances
+   *
+   * @throws {ApiError}
+   * @throws {TimeoutError}
+   */
+  async *listPagedIterator(
+    ...args: Parameters<BaseUpload['listPagedIterator']>
+  ) {
+    for await (const upload of super.listPagedIterator(...args)) {
+      yield normalizeUpload(upload);
+    }
+  }
+}

--- a/packages/cma-client/src/utilities/defaultFieldMetadata.ts
+++ b/packages/cma-client/src/utilities/defaultFieldMetadata.ts
@@ -1,0 +1,193 @@
+import type * as ApiTypes from '../generated/ApiTypes.js';
+import type { Client } from '../generated/Client.js';
+import {
+  fetchEnvironmentSettings,
+  isEnvironmentFlagActive,
+} from './environmentSettings.js';
+
+/**
+ * Legacy locale-keyed shape of an upload's `default_field_metadata`, as
+ * returned and accepted by environments where the `non_localized_focal_points`
+ * opt-in is inactive.
+ *
+ * The `uploads` resource converts to and from this shape on your behalf, so you
+ * only ever see the field-keyed one. The type is exported for those working at
+ * the raw layer, which performs no conversion.
+ */
+export type UploadLocaleKeyedDefaultFieldMetadata = {
+  [localeCode: string]: {
+    alt: string | null;
+    title: string | null;
+    custom_data: { [k: string]: unknown };
+    focal_point: { x: number; y: number } | null;
+    poster_time: number | null;
+  };
+};
+
+/**
+ * Legacy locale-keyed shape accepted on `create` / `update` request bodies
+ * by environments where the `non_localized_focal_points` opt-in is inactive.
+ * All fields are optional, matching the partial-write contract.
+ */
+export type UploadLocaleKeyedDefaultFieldMetadataInRequest = {
+  [localeCode: string]: {
+    alt?: string | null;
+    title?: string | null;
+    custom_data?: { [k: string]: unknown };
+    focal_point?: { x: number; y: number } | null;
+    poster_time?: number | null;
+  };
+};
+
+export type DefaultFieldMetadata = ApiTypes.Upload['default_field_metadata'];
+
+export type DefaultFieldMetadataInRequest = NonNullable<
+  ApiTypes.UploadUpdateSchema['default_field_metadata']
+>;
+
+/**
+ * Tells the two wire shapes apart. A field-keyed payload always carries a
+ * top-level `focal_point`, and a locale-keyed one never can: its keys are
+ * locale codes, and no locale code is the literal string `focal_point`.
+ */
+export function isFieldKeyed(
+  metadata: DefaultFieldMetadata | UploadLocaleKeyedDefaultFieldMetadata,
+): metadata is DefaultFieldMetadata {
+  return 'focal_point' in metadata;
+}
+
+/**
+ * Collapses a legacy response payload into the field-keyed shape. The API
+ * replicates the non-localized values into every locale entry on read, so every
+ * entry carries the same value and the first one is enough.
+ */
+export function fromLocaleKeyed(
+  byLocale: UploadLocaleKeyedDefaultFieldMetadata,
+): DefaultFieldMetadata {
+  const alt: Record<string, string | null> = {};
+  const title: Record<string, string | null> = {};
+  const customData: Record<string, { [k: string]: unknown }> = {};
+
+  let focalPoint: { x: number; y: number } | null = null;
+  let posterTime: number | null = null;
+  let seenAnEntry = false;
+
+  for (const [locale, entry] of Object.entries(byLocale)) {
+    alt[locale] = entry.alt;
+    title[locale] = entry.title;
+    customData[locale] = entry.custom_data;
+
+    if (!seenAnEntry) {
+      seenAnEntry = true;
+      focalPoint = entry.focal_point;
+      posterTime = entry.poster_time;
+    }
+  }
+
+  return {
+    alt,
+    title,
+    custom_data: customData,
+    focal_point: focalPoint,
+    poster_time: posterTime,
+  };
+}
+
+/**
+ * Rewrites a field-keyed patch into the legacy locale-keyed one: the localized
+ * keys are pivoted per locale, and the non-localized ones ride along on a
+ * single entry. The API takes `focal_point` / `poster_time` off the first entry
+ * that carries one and ignores the rest, so writing them once is enough — on
+ * any locale the patch already touches, or the environment's first one when it
+ * touches none.
+ */
+export function toLocaleKeyed(
+  {
+    alt,
+    title,
+    custom_data,
+    focal_point,
+    poster_time,
+  }: DefaultFieldMetadataInRequest,
+  environmentLocales: string[],
+): UploadLocaleKeyedDefaultFieldMetadataInRequest {
+  const result: UploadLocaleKeyedDefaultFieldMetadataInRequest = {};
+
+  function entryFor(locale: string) {
+    const entry = result[locale] ?? {};
+    result[locale] = entry;
+    return entry;
+  }
+
+  for (const [locale, value] of Object.entries(alt ?? {})) {
+    entryFor(locale).alt = value;
+  }
+
+  for (const [locale, value] of Object.entries(title ?? {})) {
+    entryFor(locale).title = value;
+  }
+
+  for (const [locale, value] of Object.entries(custom_data ?? {})) {
+    entryFor(locale).custom_data = value;
+  }
+
+  if (focal_point !== undefined || poster_time !== undefined) {
+    const locale = Object.keys(result)[0] ?? environmentLocales[0];
+
+    if (locale) {
+      if (focal_point !== undefined) entryFor(locale).focal_point = focal_point;
+      if (poster_time !== undefined) entryFor(locale).poster_time = poster_time;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Normalizes an upload as served by the API into the field-keyed shape the
+ * `Upload` type describes. Returns the entity untouched — no copy — when it is
+ * already field-keyed, which is the case for every environment that has taken
+ * the opt-in.
+ */
+export function normalizeUpload(upload: ApiTypes.Upload): ApiTypes.Upload {
+  const metadata = upload.default_field_metadata;
+
+  if (!metadata || isFieldKeyed(metadata)) {
+    return upload;
+  }
+
+  return { ...upload, default_field_metadata: fromLocaleKeyed(metadata) };
+}
+
+/**
+ * Encodes a `create` / `update` body into the shape the environment accepts.
+ *
+ * The environment is only consulted when there is metadata to encode, so a
+ * client that never writes asset metadata never asks — and when it does ask,
+ * the lookup is memoized and shared, so a batch of writes pays for one.
+ */
+export async function encodeDefaultFieldMetadata<
+  T extends { default_field_metadata?: DefaultFieldMetadataInRequest },
+>(client: Client, body: T): Promise<T> {
+  const metadata = body.default_field_metadata;
+
+  if (!metadata) {
+    return body;
+  }
+
+  if (await isEnvironmentFlagActive(client, 'non_localized_focal_points')) {
+    return body;
+  }
+
+  const { locales } = await fetchEnvironmentSettings(client);
+
+  return {
+    ...body,
+    // The declared type describes the field-keyed shape, which is what callers
+    // write. The legacy payload is this module's business.
+    default_field_metadata: toLocaleKeyed(
+      metadata,
+      locales,
+    ) as unknown as DefaultFieldMetadataInRequest,
+  };
+}

--- a/packages/cma-client/src/utilities/environmentSettings.ts
+++ b/packages/cma-client/src/utilities/environmentSettings.ts
@@ -1,0 +1,80 @@
+import type * as ApiTypes from '../generated/ApiTypes.js';
+import type { Client } from '../generated/Client.js';
+
+/**
+ * Every boolean an environment reports about itself in `site.meta`: the
+ * product-update opt-ins (`improved_items_listing`, `milliseconds_in_datetime`,
+ * `non_localized_focal_points`, …) plus the plain state flags.
+ *
+ * Derived from the generated type rather than listed, so a flag added to the
+ * schema is usable here as soon as the types are regenerated, with nothing to
+ * keep in sync.
+ */
+export type EnvironmentFlag = {
+  [K in keyof ApiTypes.SiteMeta]-?: boolean extends ApiTypes.SiteMeta[K]
+    ? K
+    : never;
+}[keyof ApiTypes.SiteMeta];
+
+/** How long a fetched `site` is reused before we ask again. */
+const TTL_MS = 20 * 60 * 1000;
+
+type Cache = { promise: Promise<ApiTypes.Site>; expiresAt: number };
+
+/**
+ * Keyed by client, so the cache covers every resource that asks and dies with
+ * the client that owns it.
+ */
+const caches = new WeakMap<Client, Cache>();
+
+/**
+ * `site.find()`, memoized per client for {@link TTL_MS}.
+ *
+ * The promise is cached rather than its result, so concurrent callers share one
+ * request instead of firing one each — the difference between one lookup and
+ * ten thousand when a batch job starts. A failed lookup is not cached.
+ *
+ * Everything expires on the same clock, including flags that in practice never
+ * change back: re-reading `site` every twenty minutes costs nothing next to the
+ * work these clients are doing, and it means a client stays correct across an
+ * activation that happens while it runs.
+ */
+export function fetchEnvironmentSettings(
+  client: Client,
+): Promise<ApiTypes.Site> {
+  const cached = caches.get(client);
+  const now = Date.now();
+
+  if (cached && cached.expiresAt > now) {
+    return cached.promise;
+  }
+
+  const promise = client.site.find();
+
+  // A failed lookup must not be cached, or every later caller inherits it
+  promise.catch(() => {
+    if (caches.get(client)?.promise === promise) {
+      caches.delete(client);
+    }
+  });
+
+  caches.set(client, { promise, expiresAt: now + TTL_MS });
+
+  return promise;
+}
+
+/**
+ * Whether a `site.meta` flag is on for the environment this client talks to.
+ *
+ * An API predating a flag omits it from the meta entirely, which the types
+ * don't admit but runtime does — so anything short of an explicit `true` reads
+ * as off.
+ */
+export async function isEnvironmentFlagActive(
+  client: Client,
+  flag: EnvironmentFlag,
+): Promise<boolean> {
+  const site = await fetchEnvironmentSettings(client);
+
+  return (site.meta as Partial<ApiTypes.SiteMeta> | undefined)?.[flag] === true;
+}


### PR DESCRIPTION
## The problem

`default_field_metadata` goes over the wire in two shapes:

| | Shape | Who |
|---|---|---|
| **Field-keyed** | `{ alt: { en }, title: { en }, focal_point }` | `non_localized_focal_points` opt-in **active** |
| **Locale-keyed** | `{ en: { alt, title, focal_point } }` | opt-in **inactive** — projects predating [non-localized focal points](https://www.datocms.com/product-updates/non-localized-focal-points) that haven't switched |

Each environment rejects the other with the same `422 INVALID_FORMAT.

## What this does

`uploads.create`, `update`, `find`, `list` and `listPagedIterator` convert in both directions, so **callers only ever see the field-keyed shape the types describe**:

```ts
await client.uploads.update(id, { default_field_metadata: metadata });
```

`createFromUrl`, `createFromLocalFile`, `updateFromUrl` and `updateFromLocalFile` delegate to `create`/`update`, so they are covered without being touched.

**The raw methods are deliberately unchanged** and still hand you whatever the environment sends. That is the point of the raw layer, and `UploadLocaleKeyedDefaultFieldMetadata` / `UploadLocaleKeyedDefaultFieldMetadataInRequest` stay exported for typing those payloads.

## Breaking

On an environment **without** the opt-in, the simple methods used to return the locale-keyed payload as the API sent it, and the docblock on `UploadLocaleKeyedDefaultFieldMetadata` told callers to cast the response to read it. They now return the field-keyed shape, so `upload.default_field_metadata.en.alt` reads `undefined` — **silently**. Read it as `.alt.en`, which is what the types said all along, or use `rawFind` / `rawList` to keep seeing the wire payload.

Opted-in environments are unaffected: they already spoke the field-keyed shape.