### PR TITLE
build: emit the ESM bundles for ES2018

### DIFF
--- a/.changeset/esm-target-es2018.md
+++ b/.changeset/esm-target-es2018.md
@@ -1,0 +1,24 @@
+---
+'@datocms/cma-schema-types-generator': minor
+'@datocms/cma-client-browser': minor
+'@datocms/rest-client-utils': minor
+'@datocms/cma-client-node': minor
+'@datocms/dashboard-client': minor
+'@datocms/rest-api-reference': minor
+'@datocms/rest-api-events': minor
+'@datocms/cma-client': minor
+---
+
+Build the ESM output for ES2018 instead of ES2015.
+
+At ES2015 TypeScript had to downlevel `async`/`await`, object rest and
+`for await…of` into its own `__awaiter` / `__rest` / `__asyncValues` helpers,
+which it emits guarded by a top-level `this` — meaningless in an ES module, and
+enough to make esbuild warn on every file that contains one. ES2018 has all
+three natively, so the helpers are gone and the emitted code is the code you
+wrote.
+
+The CommonJS output and the published types are unchanged. The one consequence
+is that `dist/esm` now expects an ES2018 runtime: Node 10 or later, and browsers
+with `Symbol.asyncIterator`. The bundle shipped in `@datocms/cma-client-browser`
+already targeted ES2018.

--- a/packages/cma-client-browser/tsconfig.esm.json
+++ b/packages/cma-client-browser/tsconfig.esm.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "module": "esnext",
-    "lib": ["es2015", "es2016", "es2017", "DOM"],
+    "lib": ["es2018", "DOM"],
     "outDir": "./dist/esm",
     "declarationDir": "./dist/esm",
     "isolatedModules": true

--- a/packages/cma-client-node/tsconfig.esm.json
+++ b/packages/cma-client-node/tsconfig.esm.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "module": "esnext",
+    "lib": ["es2018"],
     "outDir": "./dist/esm",
     "declarationDir": "./dist/esm",
     "isolatedModules": true

--- a/packages/cma-client/tsconfig.esm.json
+++ b/packages/cma-client/tsconfig.esm.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "module": "esnext",
+    "lib": ["es2018"],
     "outDir": "./dist/esm",
     "declarationDir": "./dist/esm",
     "isolatedModules": true

--- a/packages/cma-schema-types-generator/tsconfig.esm.json
+++ b/packages/cma-schema-types-generator/tsconfig.esm.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "module": "esnext",
+    "lib": ["es2018"],
     "outDir": "./dist/esm",
     "declarationDir": "./dist/esm",
     "isolatedModules": true

--- a/packages/dashboard-client/tsconfig.esm.json
+++ b/packages/dashboard-client/tsconfig.esm.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "module": "esnext",
+    "lib": ["es2018"],
     "outDir": "./dist/esm",
     "declarationDir": "./dist/esm",
     "isolatedModules": true

--- a/packages/rest-api-events/tsconfig.esm.json
+++ b/packages/rest-api-events/tsconfig.esm.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "module": "esnext",
     "outDir": "./dist/esm",
-    "lib": ["es2015", "es2016", "es2017", "DOM"],
+    "lib": ["es2018", "DOM"],
     "declarationDir": "./dist/esm",
     "isolatedModules": true
   }

--- a/packages/rest-api-reference/tsconfig.esm.json
+++ b/packages/rest-api-reference/tsconfig.esm.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "module": "esnext",
+    "lib": ["es2018"],
     "outDir": "./dist/esm",
     "declarationDir": "./dist/esm",
     "isolatedModules": true

--- a/packages/rest-client-utils/tsconfig.esm.json
+++ b/packages/rest-client-utils/tsconfig.esm.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2018",
     "module": "esnext",
+    "lib": ["es2018"],
     "outDir": "./dist/esm",
     "declarationDir": "./dist/esm",
     "isolatedModules": true


### PR DESCRIPTION
`npm run build` printed a wall of esbuild warnings while bundling `cma-client-browser`:

```
▲ [WARNING] Top-level "this" will be replaced with undefined since this file is an ECMAScript module

    ../rest-client-utils/dist/esm/pollJobResult.js:1:17:
      1 │ var __awaiter = (this && this.__awaiter) || function (thisArg, _arg...
```

They were harmless. With `target: es2015` TypeScript has to downlevel `async`/`await`, object rest and `for await…of` into its own `__awaiter` / `__rest` / `__asyncValues` helpers, and it emits each one guarded by `(this && this.__awaiter) || function (…) {…}` so the CommonJS emit can reuse a copy hoisted onto `exports`. In an ES module top-level `this` is `undefined` by spec, so esbuild substituting `undefined` is exactly right — the guard short-circuits and the inline helper is used.

Rather than silence the warning, this removes its cause: ES2018 has all three constructs natively (async/await landed in ES2017, object rest and `for await…of` in ES2018), so TypeScript emits no helpers at all and the shipped code is the code we wrote. `pollJobResult.js` is now a plain `export async function`, and `grep "this && this.__"` finds nothing left under any `dist/esm`.

Eight `packages/*/tsconfig.esm.json` move to `"target": "es2018"`, each gaining a matching `"lib"` because the root tsconfig pins `es2017` and `for await…of` needs `Symbol.asyncIterator` declared. `cma-client-analysis` is untouched — it runs `tsc` alone and has no `dist/esm`.

The CommonJS output and `dist/types` are byte-identical to before; CJS keeps its ES2015 target, where top-level `this` is `exports` and nothing warns. The one consequence for users is that `dist/esm` now expects an ES2018 runtime — Node 10+, browsers with `Symbol.asyncIterator`. The bundle in `cma-client-browser/esbuild.ts` already targeted ES2018, so this makes the rest of the repo consistent with it.

Changeset is `minor` for the eight packages that build an ESM output.

## Test plan

- `npm run build` — 9/9 tasks green, no esbuild warnings.

https://claude.ai/code/session_01Dw3PG2vUep69n8te7emzyQ