### PR TITLE
Publish a preview of every package on every push

### DIFF
--- a/.github/workflows/continuous-releases.yml
+++ b/.github/workflows/continuous-releases.yml
@@ -1,0 +1,42 @@
+# Every commit pushed to a branch of this repo gets an installable preview of
+# every package, without publishing anything to npm:
+#
+#     npm i https://pkg.pr.new/@datocms/cma-client@<commit-sha>
+#
+# The point is to cross a repo boundary while developing. A change to a client
+# can be tried inside a consumer that lives in another repository — `cms`, a
+# demo, a customer project — from a real tarball, instead of `npm link` or
+# pinning a git branch by hand and remembering to unpin it later.
+#
+# Pull requests opened from forks are deliberately not published: this runs on
+# pushes to branches of *this* repo, which only people with write access can
+# make, so an unreviewed fork cannot mint a URL under our namespace. If we ever
+# want fork previews too, pkg.pr.new documents an "approved pull requests only"
+# recipe that gates them behind a maintainer's review.
+name: Continuous releases
+
+on:
+  push:
+    # Every branch, `main` included. Defining `branches` on its own also means
+    # tag pushes don't trigger this, which is what we want: a tag points at a
+    # commit that was already published when it landed on its branch.
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
+      # Once for all the packages, not once per package: pkg.pr.new expects a
+      # single invocation per workflow run, and rejects the rest as spam.
+      - run: npm exec -- pkg-pr-new publish --commentWithSha './packages/*'

--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ npm run changeset
 Use `patch` for bug fixes only, `minor` for new API surface (a schema sync
 included), and `major` when something is removed or renamed.
 
+### Trying a change before it's released
+
+Every push to a branch here publishes a preview of all the packages, which you
+can install anywhere — no npm release, no `npm link`:
+
+```
+npm i https://pkg.pr.new/@datocms/cma-client@<commit-sha>
+```
+
+The exact URLs show up in the commit's check run on GitHub, and in a comment on
+the pull request once there is one. This is the supported way to try a client
+change inside a consumer that lives in another repository, so nothing needs to
+be pinned to a git branch by hand.
+
+Previews are throwaway: they are never published to npm, and the URL stops
+resolving after a while. Never commit one to a `package.json` that ships.
+
 ### Releasing
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "hyperschema-to-ts": "^0.0.11",
         "jest": "^29.7.0",
         "lint-staged": "^13.1.0",
+        "pkg-pr-new": "^0.0.88",
         "rimraf": "^3.0.2",
         "ts-jest": "^29.1.1",
         "ts-morph": "^27.0.0",
@@ -5992,6 +5993,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.88",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.88.tgz",
+      "integrity": "sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
+      }
+    },
     "node_modules/prettier": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
@@ -11523,6 +11534,12 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "pkg-pr-new": {
+      "version": "0.0.88",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.88.tgz",
+      "integrity": "sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==",
+      "dev": true
     },
     "prettier": {
       "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "hyperschema-to-ts": "^0.0.11",
     "jest": "^29.7.0",
     "lint-staged": "^13.1.0",
+    "pkg-pr-new": "^0.0.88",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.1.1",
     "ts-morph": "^27.0.0",


### PR DESCRIPTION
Every commit pushed to a branch here now produces an installable tarball of
every package, without publishing anything to npm:

```
npm i https://pkg.pr.new/@datocms/cma-client@<commit-sha>
```

## Why

This is the thing a monorepo cannot give us, because our packages are spread
across several of them. Today, trying a client change inside a consumer that
lives in another repository means pinning a git branch by hand — see
datocms/cms#365 — which works, is invisible to review, and nobody remembers to
undo. `npm link` is the other option, and it breaks in its own ways.

## Verified end-to-end on this branch

The run on commit 38b0774 published all 9 packages. Installing one of them in a
throwaway project resolves the *siblings* from the same commit, not from npm:

```
node_modules/@datocms/cma-client         https://pkg.pr.new/.../@datocms/cma-client@38b0774
node_modules/@datocms/cma-client-node    https://pkg.pr.new/@datocms/cma-client-node@38b0774
node_modules/@datocms/rest-client-utils  https://pkg.pr.new/.../@datocms/rest-client-utils@38b0774
```

while `datocms-structured-text-utils` still comes from npm, correctly — it
lives in another repo. So a change spanning several packages can be tried as
one coherent set.

## Choices worth reviewing

**Pushes only, no fork pull requests.** The workflow runs on pushes to branches
of this repo, which only people with write access can make. A fork PR publishes
nothing. This is deliberate: pkg.pr.new URLs carry our namespace, and the
tarballs are served unauthenticated, so an unreviewed fork should not be able to
mint one. pkg.pr.new documents an "approved pull requests only" recipe if we
ever want fork previews gated behind a maintainer's review — easy follow-up.

**A separate workflow, not a step in `node.js.yml`.** That one runs a matrix of
two Node versions and needs the API secrets; pkg-pr-new must run exactly once
per workflow run, and a preview is worth having even when the live-API suite is
red.

**No changeset.** Nothing about the published packages changes.

## One thing to know

Previews are throwaway and the URLs stop resolving after a while. They must
never end up in a `package.json` that ships — same rule as the git-branch pins
they replace, but at least these are obviously temporary.