### PR TITLE
Add jitter to retry waits

### DIFF
--- a/.changeset/quiet-jitters-settle.md
+++ b/.changeset/quiet-jitters-settle.md
@@ -1,0 +1,10 @@
+---
+'@datocms/rest-client-utils': patch
+---
+
+Add jitter to retry waits
+
+Many concurrent requests hitting the same rate limit, transient error, or
+timeout at once used to all retry on the exact same tick, immediately
+re-triggering the same failure. Retries (including job polling) are now
+spread out with a random extra wait on top of the required one.

--- a/packages/rest-client-utils/src/__tests__/wait.test.ts
+++ b/packages/rest-client-utils/src/__tests__/wait.test.ts
@@ -1,0 +1,22 @@
+import { withJitter } from '../wait';
+
+describe('withJitter()', () => {
+  it('never returns less than the base wait', () => {
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    expect(withJitter(2)).toBe(2);
+    expect(withJitter(45)).toBe(45);
+    randomSpy.mockRestore();
+  });
+
+  it('doubles a base wait smaller than the cap', () => {
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(1);
+    expect(withJitter(2)).toBe(4);
+    randomSpy.mockRestore();
+  });
+
+  it('caps the extra wait for a base larger than the cap', () => {
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(1);
+    expect(withJitter(45)).toBe(50);
+    randomSpy.mockRestore();
+  });
+});

--- a/packages/rest-client-utils/src/pollJobResult.ts
+++ b/packages/rest-client-utils/src/pollJobResult.ts
@@ -1,6 +1,6 @@
 import { ApiError } from './errors.js';
 import type { JobResult } from './internalTypes.js';
-import { wait } from './wait.js';
+import { wait, withJitter } from './wait.js';
 
 export async function pollJobResult(
   fetcher: () => Promise<JobResult>,
@@ -11,7 +11,9 @@ export async function pollJobResult(
   do {
     try {
       retryCount += 1;
-      await wait(retryCount * 1000);
+      // A single call (eg. a bulk publish) can spawn many jobs polled in
+      // parallel; jitter keeps them from all landing on the same poll tick.
+      await wait(withJitter(retryCount) * 1000);
       jobResult = await fetcher();
     } catch (e) {
       if (!(e instanceof ApiError) || e.response.status !== 404) {

--- a/packages/rest-client-utils/src/request.ts
+++ b/packages/rest-client-utils/src/request.ts
@@ -12,7 +12,7 @@ import {
   CanceledPromiseError,
   makeCancelablePromise,
 } from './makeCancelablePromise.js';
-import { wait } from './wait.js';
+import { wait, withJitter } from './wait.js';
 
 const isBrowser =
   typeof window !== 'undefined' && typeof window.document !== 'undefined';
@@ -301,7 +301,7 @@ export async function request<T>(options: RequestOptions): Promise<T> {
         }
       }
 
-      await wait(waitTimeInSecs * 1000);
+      await wait(withJitter(waitTimeInSecs) * 1000);
 
       return request({ ...options, retryCount: retryCount + 1 });
     }
@@ -380,7 +380,7 @@ export async function request<T>(options: RequestOptions): Promise<T> {
         );
       }
 
-      await wait(retryCount * 1000);
+      await wait(withJitter(retryCount) * 1000);
 
       return request({ ...options, retryCount: retryCount + 1 });
     }
@@ -398,7 +398,7 @@ export async function request<T>(options: RequestOptions): Promise<T> {
           );
         }
 
-        await wait(retryCount * 1000);
+        await wait(withJitter(retryCount) * 1000);
 
         return request({ ...options, retryCount: retryCount + 1 });
       }

--- a/packages/rest-client-utils/src/wait.ts
+++ b/packages/rest-client-utils/src/wait.ts
@@ -3,3 +3,30 @@ export function wait(time: number) {
     setTimeout(resolve, time);
   });
 }
+
+/**
+ * The CMA enforces a single rate-limit window — 60 requests / 3 seconds —
+ * shared by the whole project (not per token). `X-RateLimit-Reset` tells us
+ * how many seconds are left until it refills; when no such header applies
+ * (transient errors, timeouts, job polling) we fall back to `retryCount`
+ * seconds instead, which keeps growing with every retry. Either way, many
+ * callers can hit the same failure together (e.g. a static site generator
+ * rendering pages in parallel, all against the same project), and without
+ * jitter they'd all wake up and retry on the same tick, reproducing the
+ * exact burst that got them rate-limited.
+ *
+ * We never wait less than `baseSeconds` — retrying before the window refills
+ * (or before a transient failure has had time to clear) is essentially
+ * guaranteed to fail again. On top of that we add a random extra, capped at
+ * `JITTER_CAP_SECONDS`: what desynchronizes concurrent retries is a few
+ * seconds of spread, not a delay proportional to the wait itself — doubling
+ * a 1s wait is fine, but doubling a wait that's already grown to 45s (many
+ * retries in) would needlessly leave callers waiting far longer than needed.
+ */
+const JITTER_CAP_SECONDS = 5;
+
+export function withJitter(baseSeconds: number): number {
+  return (
+    baseSeconds + Math.random() * Math.min(baseSeconds, JITTER_CAP_SECONDS)
+  );
+}


### PR DESCRIPTION
## Summary
- A burst of concurrent calls sharing the same project (rate limiting is project-wide, not per-token) hitting a 429, transient error, or timeout used to all compute the same wait time and retry on the exact same tick, immediately re-triggering the same failure. Job polling had the same issue when a single call spawns many parallel jobs (e.g. a bulk publish).
- All retry waits in `rest-client-utils` (rate limiting, transient errors, timeouts, job polling) now add a random extra on top of the required wait — capped at 5s regardless of how long the base wait already is, since a few seconds of spread is enough to desynchronize concurrent retries without needlessly stretching a wait that's already grown large after several retries.
- Added `.changeset` for a patch release of `@datocms/rest-client-utils` (consumed by `cma-client`, `cma-client-node`, `cma-client-browser`, `dashboard-client`).

## Test plan
- [x] `npx jest --globalSetup= --testPathPattern='packages/rest-client-utils'` — all suites pass, including new `withJitter()` unit tests
- [x] `npx biome check packages/rest-client-utils/src` — clean

https://claude.ai/code/session_01PY2yju9C9qdHdroj3zhbvc